### PR TITLE
fix [home|away]_turnovers

### DIFF
--- a/nfldb/types.py
+++ b/nfldb/types.py
@@ -2110,7 +2110,7 @@ class Game (SQLGame):
         dbg.home_score_q3 = g.score_home_q3
         dbg.home_score_q4 = g.score_home_q4
         dbg.home_score_q5 = g.score_home_q5
-        dbg.home_turnovers = int(g.data['home']['to'])
+        dbg.home_turnovers = int(g.data['home']['stats']['team']['trnovr'])
         dbg.away_team = nfldb.team.standard_team(g.away)
         dbg.away_score = g.score_away
         dbg.away_score_q1 = g.score_away_q1
@@ -2118,7 +2118,7 @@ class Game (SQLGame):
         dbg.away_score_q3 = g.score_away_q3
         dbg.away_score_q4 = g.score_away_q4
         dbg.away_score_q5 = g.score_away_q5
-        dbg.away_turnovers = int(g.data['away']['to'])
+        dbg.away_turnovers = int(g.data['away']['stats']['team']['trnovr'])
 
         # If it's been 8 hours since game start, we always conclude finished!
         if (now() - dbg.start_time).total_seconds() >= (60 * 60 * 8):


### PR DESCRIPTION
This addresses a discrepancy between the game.xxx_turnovers in the game table and the incoming JSON from nfl.com
I don't know what 'to' is, but I'm fairly certain that it is not turnovers as the data doesn't match up with the play-by-play data. The changes here make the statistical category match up with the play-by-play.

Unfortunately, the existing data is already wrong since these values are written to the db. The following code fixes up the DB.
```
with nfldb.Tx(db) as cursor:
  cursor.execute("SET TIME ZONE 'UTC'")
  for year in range(start, end+1):
      games = nflgame.games(year)
      for game in games:
        dbg = nfldb.Game.from_id(db,game.eid)
        dbg.home_turnovers = int(game.data['home']['stats']['team']['trnovr'])
        dbg.away_turnovers = int(game.data['away']['stats']['team']['trnovr'])
        dbg._save(cursor)
```