### PR TITLE
Fix Home|Away Turnovers

### DIFF
--- a/nfldb/types.py
+++ b/nfldb/types.py
@@ -2110,7 +2110,10 @@ class Game (SQLGame):
         dbg.home_score_q3 = g.score_home_q3
         dbg.home_score_q4 = g.score_home_q4
         dbg.home_score_q5 = g.score_home_q5
-        dbg.home_turnovers = int(g.data['home']['to'])
+        try:
+            dbg.home_turnovers = int(g.stats_home.turnovers)
+        except KeyError:
+            dbg.home_turnovers = 0
         dbg.away_team = nfldb.team.standard_team(g.away)
         dbg.away_score = g.score_away
         dbg.away_score_q1 = g.score_away_q1
@@ -2118,7 +2121,10 @@ class Game (SQLGame):
         dbg.away_score_q3 = g.score_away_q3
         dbg.away_score_q4 = g.score_away_q4
         dbg.away_score_q5 = g.score_away_q5
-        dbg.away_turnovers = int(g.data['away']['to'])
+        try:
+            dbg.away_turnovers = int(g.stats_away.turnovers)
+        except KeyError:
+            dbg.away_turnovers = 0
 
         # If it's been 8 hours since game start, we always conclude finished!
         if (now() - dbg.start_time).total_seconds() >= (60 * 60 * 8):

--- a/scripts/nfldb-update
+++ b/scripts/nfldb-update
@@ -26,6 +26,9 @@ if __name__ == '__main__':
        help='When set, ALL game schedules are refreshed from the data in '
             'nflgame. (In normal operation, only the current week\'s schedule '
             'is refreshed.)')
+    aa('--update-turnovers', action='store_true',
+       help='When set, ALL games will have away_turnovers and home_turnovers '
+        'updated with the correct values from NFL.com')
     aa('--batch-size', type=int, default=5,
        help='The number of games to batch before sending data to the '
             'database. In normal operation, this setting will not have much '


### PR DESCRIPTION
Modified version of #197.

Fixed home_turnovers and away_turnovers mapping from timeout mapping.
Added command line option to update game turnovers.

Corrects #281.